### PR TITLE
Need i386 in the script.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,3 +28,9 @@ chmod +x install.sh
 
 # Rustdesk windows powershell install script
 Generates a powershell script for install grabbing WAN IP and Key currently in /opt/rustdesk but will be moved to a web url for easy deployment.
+
+# Tips
+
+if you want to restart the services use the following commands:
+sudo systemctl restart rustdesksignal
+sudo systemctl restart rustdeskrelay

--- a/install.sh
+++ b/install.sh
@@ -190,7 +190,7 @@ done
 pubname=$(find /opt/rustdesk -name "*.pub")
 key=$(cat "${pubname}")
 
-rm rustdesk-server-linux-x64.zip
+rm rustdesk-server-linux-amd64.zip
 
 # Choice for DNS or IP
 PS3='Please choose if you want to download configs and install HTTP server:'

--- a/install.sh
+++ b/install.sh
@@ -117,8 +117,8 @@ cd /opt/rustdesk/ || exit 1
 
 #Download latest version of Rustdesk
 RDLATEST=$(curl https://api.github.com/repos/rustdesk/rustdesk-server/releases/latest -s | grep "tag_name"| awk '{print substr($2, 2, length($2)-3) }')
-wget "https://github.com/rustdesk/rustdesk-server/releases/download/${RDLATEST}/rustdesk-server-linux-x64.zip"
-unzip rustdesk-server-linux-x64.zip
+wget "https://github.com/rustdesk/rustdesk-server/releases/download/${RDLATEST}/rustdesk-server-linux-amd64.zip"
+unzip rustdesk-server-linux-amd64.zip
 
 # Make Folder /var/log/rustdesk/
 if [ ! -d "/var/log/rustdesk" ]; then

--- a/install.sh
+++ b/install.sh
@@ -119,6 +119,8 @@ cd /opt/rustdesk/ || exit 1
 RDLATEST=$(curl https://api.github.com/repos/rustdesk/rustdesk-server/releases/latest -s | grep "tag_name"| awk '{print substr($2, 2, length($2)-3) }')
 wget "https://github.com/rustdesk/rustdesk-server/releases/download/${RDLATEST}/rustdesk-server-linux-amd64.zip"
 unzip rustdesk-server-linux-amd64.zip
+cd amd64
+mv * /opt/rustdesk/
 
 # Make Folder /var/log/rustdesk/
 if [ ! -d "/var/log/rustdesk" ]; then

--- a/install.sh
+++ b/install.sh
@@ -121,6 +121,8 @@ wget "https://github.com/rustdesk/rustdesk-server/releases/download/${RDLATEST}/
 unzip rustdesk-server-linux-amd64.zip
 cd amd64
 mv * /opt/rustdesk/
+chmod +x /opt/rustdesk/hbbs
+chmod +x /opt/rustdesk/hbbr
 
 # Make Folder /var/log/rustdesk/
 if [ ! -d "/var/log/rustdesk" ]; then

--- a/install.sh
+++ b/install.sh
@@ -119,10 +119,10 @@ cd /opt/rustdesk/ || exit 1
 RDLATEST=$(curl https://api.github.com/repos/rustdesk/rustdesk-server/releases/latest -s | grep "tag_name"| awk '{print substr($2, 2, length($2)-3) }')
 wget "https://github.com/rustdesk/rustdesk-server/releases/download/${RDLATEST}/rustdesk-server-linux-amd64.zip"
 unzip rustdesk-server-linux-amd64.zip
-cd amd64
-mv * /opt/rustdesk/
+mv amd64/* /opt/rustdesk/
 chmod +x /opt/rustdesk/hbbs
 chmod +x /opt/rustdesk/hbbr
+
 
 # Make Folder /var/log/rustdesk/
 if [ ! -d "/var/log/rustdesk" ]; then


### PR DESCRIPTION
I changed what wget downloads in the script. Maybe this could be added somehow? Some of us still use 32 bit for our servers (especially if the CPU is 32 bit architecture only). I attached the script.
[i386-RustDesk-server-install.zip](https://github.com/techahold/rustdeskinstall/files/10104552/i386-RustDesk-server-install.zip)
