### PR TITLE
Update update.sh

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -5,7 +5,7 @@ uname=$(whoami) # not used btw .. yet
 
 # Get current release version
 RDLATEST=$(curl https://api.github.com/repos/rustdesk/rustdesk-server/releases/latest -s | grep "tag_name"| awk '{print substr($2, 2, length($2)-3) }' | sed 's/-.*//')
-RDCURRENT=$(/opt/rustdesk/hbbr --version | sed -r 's/hbbr (.*)-.*/\1/')
+RDCURRENT=$(/opt/rustdesk/hbbr --version | sed -r 's/hbbr (.*).*/\1/')
 
 if [ $RDLATEST == $RDCURRENT ]; then
     echo "Same version no need to update."


### PR DESCRIPTION
Fixing hbbr version output to make update.sh great again, here is the output of the things as they work right now without this fix:

```
# /root/update.sh
+ set -e
++ whoami
+ uname=root
++ sed 's/-.*//'
++ awk '{print substr($2, 2, length($2)-3) }'
++ grep tag_name
++ curl https://api.github.com/repos/rustdesk/rustdesk-server/releases/latest -s
+ RDLATEST=1.1.8
++ sed -r 's/hbbr (.*)-.*/\1/'
++ /opt/rustdesk/hbbr --version
+ RDCURRENT='hbbr 1.1.8'
+ '[' 1.1.8 == hbbr 1.1.8 ']'
/root/update.sh: line 12: [: too many arguments
+ sudo systemctl stop gohttpserver.service
+ sudo systemctl stop rustdesksignal.service
+ sudo systemctl stop rustdeskrelay.service
++ uname -m
+ ARCH=x86_64
+ '[' -f /etc/os-release ']'
+ . /etc/os-release
++ PRETTY_NAME='Ubuntu 22.04.1 LTS'
<...>
```