### PR TITLE
feat: add uninstall script

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+echo "Stopping and disabling RustDesk services..."
+
+# Stop and disable services
+sudo systemctl stop rustdesksignal.service 2>/dev/null
+sudo systemctl stop rustdeskrelay.service 2>/dev/null
+sudo systemctl stop gohttpserver.service 2>/dev/null
+
+sudo systemctl disable rustdesksignal.service 2>/dev/null
+sudo systemctl disable rustdeskrelay.service 2>/dev/null
+sudo systemctl disable gohttpserver.service 2>/dev/null
+
+# Remove service files
+sudo rm -f /etc/systemd/system/rustdesksignal.service
+sudo rm -f /etc/systemd/system/rustdeskrelay.service
+sudo rm -f /etc/systemd/system/gohttpserver.service
+
+# Reload systemd
+sudo systemctl daemon-reload
+
+echo "Removing RustDesk binaries and logs..."
+
+# Remove binaries and logs
+sudo rm -rf /opt/rustdesk
+sudo rm -rf /var/log/rustdesk
+
+# Remove gohttp server and logs (if used)
+sudo rm -rf /opt/gohttp
+sudo rm -rf /var/log/gohttp
+
+echo "RustDesk server and optional HTTP service have been removed."
+echo "Don't forget to clean up any firewall/NAT rules if needed."


### PR DESCRIPTION
This commit introduces a full uninstall script to completely remove the RustDesk server components installed via the install.sh script. 

The script performs the following actions:

- Stops and disables the systemd services:
  - rustdesksignal.service (hbbs)
  - rustdeskrelay.service (hbbr)
  - gohttpserver.service (optional HTTP installer service)
  
- Removes the corresponding service unit files from /etc/systemd/system/
- Deletes all related directories and binaries:
  - /opt/rustdesk/
  - /var/log/rustdesk/
  - /opt/gohttp/ (if present)
  - /var/log/gohttp/ (if present)

It ensures a clean environment for a fresh installation or a complete removal of RustDesk from the host.

Note: Any NAT/firewall rules are not automatically removed and must be manually cleaned up.